### PR TITLE
Update context menu option to fix spelling

### DIFF
--- a/menus/css-in-js.json
+++ b/menus/css-in-js.json
@@ -2,7 +2,7 @@
   "context-menu": {
     "atom-text-editor": [
       {
-        "label": "Convet CSS in JS",
+        "label": "Convert CSS in JS",
         "command": "css-in-js:convert"
       }
     ]


### PR DESCRIPTION
Just a quick update.  I noticed while using this plugin in Nuclide that Convert was misspelled in the menu